### PR TITLE
Suppress seed page content churn

### DIFF
--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -525,8 +525,7 @@ def monitor_site(
         if error:
             fetch_log.append({"url": url, "status_code": status_code, "error": error})
             continue
-        page_kind = page_type if page_type != "seed" else score_url(url, site)[1]
-        snapshot = snapshot_page(url, html, status_code, page_kind)
+        snapshot = snapshot_page(url, html, status_code, page_type)
         if snapshot.text_hash in seen_hashes:
             continue
         seen_hashes.add(snapshot.text_hash)
@@ -584,6 +583,8 @@ def diff_sites(previous: dict[str, Any], current: dict[str, Any]) -> list[dict[s
             continue
         signal_changed = before.get("signal_hash") != page.get("signal_hash")
         content_changed = before.get("text_hash") != page.get("text_hash")
+        if page.get("page_type") == "seed" and content_changed and not signal_changed:
+            continue
         if signal_changed or content_changed:
             events.append(
                 {

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -140,6 +140,58 @@ def test_diff_detects_body_hash_change_even_when_signal_same() -> None:
     assert events[0]["change_type"] == "content"
 
 
+def test_diff_suppresses_seed_page_content_churn() -> None:
+    previous = {
+        "pages": {
+            "https://example.com/blog": {
+                "page_type": "seed",
+                "signal_hash": "same",
+                "text_hash": "old",
+                "title": "Blog",
+            }
+        }
+    }
+    current = {
+        "pages": {
+            "https://example.com/blog": {
+                "page_type": "seed",
+                "signal_hash": "same",
+                "text_hash": "new",
+                "title": "Blog",
+                "summary": "Listing page changed",
+            }
+        }
+    }
+    assert diff_sites(previous, current) == []
+
+
+def test_diff_reports_seed_page_signal_change() -> None:
+    previous = {
+        "pages": {
+            "https://example.com/blog": {
+                "page_type": "seed",
+                "signal_hash": "old",
+                "text_hash": "old",
+                "title": "Blog",
+            }
+        }
+    }
+    current = {
+        "pages": {
+            "https://example.com/blog": {
+                "page_type": "seed",
+                "signal_hash": "new",
+                "text_hash": "new",
+                "title": "AI search blog",
+                "summary": "Listing page retitled",
+            }
+        }
+    }
+    events = diff_sites(previous, current)
+    assert events[0]["event_type"] == "updated_page"
+    assert events[0]["change_type"] == "signal"
+
+
 def test_snapshot_state_excludes_raw_body_sample() -> None:
     snapshot = snapshot_page(
         "https://example.com/blog/ai-search",


### PR DESCRIPTION
## Summary
- keep seed/listing pages in state without reporting body-only churn
- still report seed page signal/title changes
- add regression tests for both behaviors

## Verification
- python -m pytest -q
- local monitor smoke with current monitor-state: has_changes=false, total_events=0